### PR TITLE
Feat: Add more accent colors and remove logo

### DIFF
--- a/themes/risterio-simple/static/css/style.css
+++ b/themes/risterio-simple/static/css/style.css
@@ -12,7 +12,11 @@ body {
 }
 
 :root {
-    --accent-color: #FFFF00; /* Bright yellow accent */
+    --accent-color-yellow: #FFFF00; /* Bright yellow accent */
+    --accent-color-cyan: #00FFFF;
+    --accent-color-magenta: #FF00FF;
+    --accent-color-green: #00FF00;
+    --accent-color-red: #FF0000;
     --background-color: #FFFFFF;
     --text-color: #000000;
     --header-bg-color: #000000;
@@ -21,7 +25,7 @@ body {
     --footer-text-color: #FFFFFF;
     --border-color: #000000;
     --link-color: #0000FF; /* Standard blue for links, can be adjusted */
-    --link-hover-bg-color: #FFFF00;
+    --link-hover-bg-color: var(--accent-color-yellow); /* Default hover to yellow */
     --link-hover-text-color: #000000;
 }
 
@@ -85,6 +89,8 @@ article h2 a:hover {
     border-bottom: 1px solid var(--border-color);
     padding-bottom: 0.5em;
     text-transform: uppercase;
+    border-left: 5px solid var(--accent-color-cyan); /* Cyan accent for article info */
+    padding-left: 10px;
 }
 
 
@@ -93,6 +99,7 @@ aside {
     background-color: var(--background-color); /* Consistent background */
     border: 3px solid var(--border-color);
     padding: 1.5em;
+    border-left: 5px solid var(--accent-color-magenta); /* Magenta accent for aside */
 }
 
 aside h2 {
@@ -101,6 +108,7 @@ aside h2 {
     border-bottom: 2px solid var(--border-color);
     padding-bottom: 0.3em;
     text-transform: uppercase;
+    color: var(--accent-color-magenta); /* Magenta for aside headings */
 }
 
 aside ul {
@@ -121,7 +129,7 @@ aside ul li:last-child a {
 
 aside ul li a:hover {
     color: var(--link-hover-text-color);
-    background-color: var(--link-hover-bg-color);
+    background-color: var(--accent-color-green); /* Green hover for aside links */
 }
 
 
@@ -133,12 +141,13 @@ header {
     align-items: center;
     flex-wrap: wrap;
     border-bottom-width: 5px; /* Thicker bottom border for header */
+    border-top: 5px solid var(--accent-color-red); /* Red accent for header top */
 }
 
 .site-logo {
     max-height: 60px; /* Slightly larger logo */
     margin-right: 20px;
-    border: 2px solid var(--accent-color); /* Accent border for logo */
+    border: 2px solid var(--accent-color-yellow); /* Yellow accent border for logo */
 }
 
 header h1 {
@@ -153,7 +162,7 @@ header h1 a {
 }
 
 header h1 a:hover {
-    color: var(--accent-color); /* Accent color on hover */
+    color: var(--accent-color-yellow); /* Yellow accent color on hover */
 }
 
 header .subtitle {
@@ -163,6 +172,8 @@ header .subtitle {
     margin-left: 5px;
     flex-basis: 100%;
     font-family: monospace; /* Monospace for subtitle for a raw feel */
+    border-left: 3px solid var(--accent-color-green); /* Green accent for subtitle */
+    padding-left: 10px;
 }
 
 
@@ -170,6 +181,7 @@ nav {
     background-color: var(--background-color); /* Stark background for nav */
     padding: 0; /* Padding handled by ul/li */
     border-bottom-width: 3px;
+    border-top: 3px solid var(--accent-color-cyan); /* Cyan border top for nav */
 }
 
 nav ul {
@@ -198,7 +210,7 @@ nav ul li:last-child a {
 }
 
 nav ul li a:hover, nav ul li.active a {
-    background-color: var(--accent-color);
+    background-color: var(--accent-color-yellow); /* Yellow hover for nav items */
     color: var(--text-color);
 }
 
@@ -209,19 +221,32 @@ footer {
     color: var(--footer-text-color);
     padding: 2em 1.5em;
     border-top-width: 5px; /* Thicker top border for footer */
+    border-bottom: 5px solid var(--accent-color-magenta); /* Magenta border bottom for footer */
 }
 
 footer a {
-    color: var(--accent-color); /* Accent color for links in footer */
+    color: var(--accent-color-yellow); /* Yellow accent color for links in footer */
     text-decoration: underline;
 }
 footer a:hover {
-    background-color: var(--accent-color);
+    background-color: var(--accent-color-yellow);
     color: var(--text-color);
     text-decoration: none;
 }
 
 /* General links */
+/* Using a class for more targeted link coloring if needed, e.g., for specific sections */
+.link-cyan { color: var(--accent-color-cyan); }
+.link-magenta { color: var(--accent-color-magenta); }
+.link-green { color: var(--accent-color-green); }
+.link-red { color: var(--accent-color-red); }
+
+.link-cyan:hover { background-color: var(--accent-color-cyan); color: var(--text-color); }
+.link-magenta:hover { background-color: var(--accent-color-magenta); color: var(--text-color); }
+.link-green:hover { background-color: var(--accent-color-green); color: var(--text-color); }
+.link-red:hover { background-color: var(--accent-color-red); color: var(--text-color); }
+
+
 a {
     color: var(--link-color);
     text-decoration: underline;

--- a/themes/risterio-simple/templates/base.html
+++ b/themes/risterio-simple/templates/base.html
@@ -16,9 +16,9 @@
 <body>
 <div class="container">
     <header>
-        {% if SITEIMAGE %}
-        <a href="{{ SITEURL }}/"><img src="{{ SITEURL }}/{{ SITEIMAGE }}" alt="{{ SITENAME }} Logo" class="site-logo"></a>
-        {% endif %}
+        {# {% if SITEIMAGE %} #}
+        {# <a href="{{ SITEURL }}/"><img src="{{ SITEURL }}/{{ SITEIMAGE }}" alt="{{ SITENAME }} Logo" class="site-logo"></a> #}
+        {# {% endif %} #}
         <h1><a href="{{ SITEURL }}/">{{ SITENAME }}</a></h1>
         {% if SITESUBTITLE %}
         <p class="subtitle">{{ SITESUBTITLE }}</p>


### PR DESCRIPTION
Incorporates additional accent colors (cyan, magenta, green, red) into the Neo-Brutalist theme for `risterio-simple`.

- CSS variables for new colors defined in `themes/risterio-simple/static/css/style.css`.
- Cyan used for article info border and nav top border.
- Magenta used for aside border/headings and footer bottom border.
- Green used for aside link hovers and subtitle border.
- Red used for header top border.

Also removes the site logo from the header template (`themes/risterio-simple/templates/base.html`) by commenting out the image tag.