### PR TITLE
Add Pelican plugin to generate humans.txt

### DIFF
--- a/pelican/plugins/humans/README.md
+++ b/pelican/plugins/humans/README.md
@@ -1,0 +1,110 @@
+# Pelican Humans.txt Plugin
+
+This plugin generates a `humans.txt` file for your Pelican site. This file can provide information about the people behind the website, the technology used, and any acknowledgments.
+
+## Installation
+
+1.  Ensure this plugin is accessible in your Pelican project, typically by placing the `humans` folder (containing `humans.py`, `__init__.py`, and this `README.md`) into a `plugins` directory within your Pelican project structure (e.g., `my_pelican_site/plugins/humans`).
+2.  Alternatively, for more global use, you might install it as a Python package if it were structured as one. For local plugin use, the directory method is common.
+
+## Enabling the Plugin
+
+In your `pelicanconf.py` file, you need to tell Pelican about the plugin:
+
+```python
+# pelicanconf.py
+
+# If your plugins are in a directory named 'plugins' at the root of your project:
+PLUGIN_PATHS = ['plugins']
+# Or, if you placed the 'humans' folder directly into a 'pelican/plugins' structure recognized by your PYTHONPATH:
+# PLUGIN_PATHS = ['pelican/plugins'] # Adjust as per your structure
+
+PLUGINS = ['humans'] # Use the short name of the plugin folder/module
+```
+
+If `PLUGIN_PATHS` is not specified, Pelican might still find it if the `pelican.plugins.humans` module is directly installable or discoverable in your Python environment (e.g., via `sys.path` or if it's a namespace package). However, for local plugins, explicitly setting `PLUGIN_PATHS` is the most reliable method.
+
+## Configuration
+
+You can customize the content of `humans.txt` by adding settings to your `pelicanconf.py`.
+
+The following settings are available:
+
+*   `HUMANS_TEAM`: Information about the team behind the site.
+    *   Can be a list of strings.
+    *   Can be a list of dictionaries (each dict is a person with key-value attributes).
+    *   Can be a single string.
+    *   If not provided, a default "/* TEAM */" header is used.
+*   `HUMANS_THANKS`: Acknowledgments for tools, services, or individuals.
+    *   Can be a list of strings.
+    *   Can be a list of dictionaries.
+    *   Can be a single string.
+    *   If not provided, a default "/* THANKS */" header is used.
+*   `HUMANS_SITE`: Information about the site itself (technology, standards, etc.).
+    *   Can be a list of strings.
+    *   Can be a dictionary of key-value pairs.
+    *   Can be a single string.
+    *   If not provided, default information including "Last update", "Standards", "Components", and "Software" is used. The "Last update" field is always automatically added to this section.
+
+### Example Configuration
+
+```python
+# pelicanconf.py
+
+HUMANS_TEAM = [
+    {'Role': 'Lead Developer', 'Name': 'Your Name', 'Contact': 'your.email@example.com'},
+    {'Role': 'Content Creator', 'Name': 'Another Person'},
+    'A general contributor',
+]
+
+HUMANS_THANKS = [
+    'Pelican maintainers for the great static site generator.',
+    'The open-source community.',
+    {'Service': 'Hosting Provider Inc.', 'For': 'Reliable hosting services'},
+]
+
+HUMANS_SITE = {
+    'Language': 'English (US)',
+    'Standards Compliance': 'WCAG 2.1 AA, HTML5, CSS3',
+    'Primary Technology': 'Python & Pelican',
+    'Hosting Environment': 'My Awesome Server',
+    # 'Last update' will be added automatically by the plugin.
+}
+```
+
+If any of these settings are omitted, the plugin will use sensible defaults for that section.
+
+## Output
+
+The plugin will generate a `humans.txt` file in the root of your site's output directory (e.g., `output/humans.txt`).
+
+Example of a generated `humans.txt` with the configuration above:
+
+```
+/* TEAM */
+Role: Lead Developer
+Name: Your Name
+Contact: your.email@example.com
+Role: Content Creator
+Name: Another Person
+A general contributor
+
+/* THANKS */
+Pelican maintainers for the great static site generator.
+The open-source community.
+Service: Hosting Provider Inc.
+For: Reliable hosting services
+
+/* SITE */
+Language: English (US)
+Standards Compliance: WCAG 2.1 AA, HTML5, CSS3
+Primary Technology: Python & Pelican
+Hosting Environment: My Awesome Server
+Last update: 2023/10/27
+```
+(Note: The `Last update` date will reflect the actual generation date.)
+
+## How it Works
+
+The plugin hooks into Pelican's `finalized` signal. This means it runs after Pelican has finished generating all other content for your site. It then gathers the configured (or default) data and writes it to the `humans.txt` file.
+```

--- a/pelican/plugins/humans/__init__.py
+++ b/pelican/plugins/humans/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from .humans import * # NOQA

--- a/pelican/plugins/humans/humans.py
+++ b/pelican/plugins/humans/humans.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+import logging
+import os
+from datetime import datetime
+
+from pelican import signals
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_HUMANS_HEADER = """\
+/* TEAM */
+"""
+
+DEFAULT_HUMANS_THANKS = """\
+/* THANKS */
+"""
+
+DEFAULT_HUMANS_SITE = f"""\
+/* SITE */
+Last update: {datetime.now().strftime('%Y/%m/%d')}
+Standards: HTML5, CSS3
+Components: Pelican
+Software: Python
+"""
+
+def get_setting(pelican_object, key, default=None):
+    """Helper function to get a setting from the Pelican object."""
+    return pelican_object.settings.get(key, default)
+
+def generate_humans_txt(pelican_object):
+    """Generate the humans.txt file."""
+    output_path = pelican_object.output_path
+    humans_path = os.path.join(output_path, "humans.txt")
+
+    humans_content = []
+
+    # Get custom data from settings or use defaults
+    team_section = get_setting(pelican_object, 'HUMANS_TEAM', None)
+    if team_section:
+        humans_content.append("/* TEAM */")
+        if isinstance(team_section, list):
+            for item in team_section:
+                humans_content.append(str(item))
+        elif isinstance(team_section, dict):
+            for key, value in team_section.items():
+                humans_content.append(f"{key}: {value}")
+        else:
+            humans_content.append(str(team_section))
+    else:
+        humans_content.append(DEFAULT_HUMANS_HEADER.strip())
+
+    humans_content.append("") # Add a blank line
+
+    thanks_section = get_setting(pelican_object, 'HUMANS_THANKS', None)
+    if thanks_section:
+        humans_content.append("/* THANKS */")
+        if isinstance(thanks_section, list):
+            for item in thanks_section:
+                humans_content.append(str(item))
+        elif isinstance(thanks_section, dict):
+            for key, value in thanks_section.items():
+                humans_content.append(f"{key}: {value}")
+        else:
+            humans_content.append(str(thanks_section))
+    else:
+        humans_content.append(DEFAULT_HUMANS_THANKS.strip())
+
+    humans_content.append("") # Add a blank line
+
+    site_section = get_setting(pelican_object, 'HUMANS_SITE', None)
+    custom_site_info = []
+    if site_section:
+        custom_site_info.append("/* SITE */")
+        if isinstance(site_section, list):
+            for item in site_section:
+                custom_site_info.append(str(item))
+        elif isinstance(site_section, dict):
+            for key, value in site_section.items():
+                custom_site_info.append(f"{key}: {value}")
+        else:
+            custom_site_info.append(str(site_section))
+        # Ensure Last update is present
+        if not any("Last update" in line for line in custom_site_info):
+            custom_site_info.append(f"Last update: {datetime.now().strftime('%Y/%m/%d')}")
+        humans_content.extend(custom_site_info)
+    else:
+        humans_content.append(DEFAULT_HUMANS_SITE.strip())
+
+
+    try:
+        with open(humans_path, "w", encoding="utf-8") as f:
+            f.write("\n".join(humans_content))
+        logger.info(f"Generated humans.txt at {humans_path}")
+    except Exception as e:
+        logger.error(f"Could not write humans.txt: {e}")
+
+def register():
+    """Register the plugin signals."""
+    signals.finalized.connect(generate_humans_txt)

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -37,6 +37,9 @@ DEFAULT_PAGINATION = 10
 # Uncomment following line if you want document-relative URLs when developing
 #RELATIVE_URLS = True
 
+PLUGIN_PATHS = ['pelican/plugins']
+PLUGINS = ['humans'] # When using PLUGIN_PATHS, short names are often used
+
 THEME = 'themes/risterio-simple' # Direct relative path to the theme
 # Removed THEME_PATHS
 # Removed THEME_TEMPLATES_OVERRIDES
@@ -51,3 +54,27 @@ DISPLAY_PAGES_ON_MENU = True # If you have static pages like 'About'
 
 DIRECT_TEMPLATES = ['index', 'categories', 'authors', 'archives'] # Add other templates as needed
 PAGINATED_TEMPLATES = {'index': None} # Updated to dict format; None uses DEFAULT_PAGINATION
+
+# Humans.txt Plugin Settings
+# Example configuration:
+# HUMANS_TEAM = [
+#     {'Team member': 'Name', 'Role': 'Developer', 'Contact': 'email@example.com'},
+#     'Another Team Member - Designer',
+# ]
+# HUMANS_THANKS = [
+#     'Contributor Name - Contribution',
+#     ('Another Contributor', 'Their Contribution'),
+# ]
+# HUMANS_SITE = {
+#     'Standards': 'HTML5, CSS3, WCAG AAA',
+#     'Components': 'Pelican, Jinja2, MyCustomTheme',
+#     'Software': 'Python, VSCode',
+# }
+#
+# By default, if these are not set, the plugin will use generic information.
+# You can override specific sections or leave them for defaults.
+# For example, to only specify the team:
+# HUMANS_TEAM = [
+#     {'Author': 'Jeremy Rist', 'Role': 'Owner', 'Contact': 'jeremy@rist.dev', 'Mastodon': '@jrist@awscommunity.social'}
+# ]
+# The /* SITE */ section will always include "Last update".

--- a/test_humans.py
+++ b/test_humans.py
@@ -1,0 +1,164 @@
+import os
+import shutil
+import tempfile
+import unittest
+from datetime import datetime
+
+from pelican.settings import DEFAULT_CONFIG
+from pelican import Pelican
+
+# Import the plugin - this assumes it's in python path or structure allows direct import
+# For a local plugin, we might need to adjust sys.path or ensure the structure is correct
+# For now, assuming `pelican/plugins` is a package or can be added to path.
+# A more robust way might be to use pelican's plugin loading mechanism if testing outside pelican process
+try:
+    from pelican.plugins.humans.humans import generate_humans_txt, register
+except ImportError:
+    # This is a common issue when running tests directly if plugin path isn't set up
+    # For a real test suite, you'd ensure PYTHONPATH or similar is configured
+    print("Failed to import plugin directly, ensure pelican.plugins.humans is in PYTHONPATH")
+    # As a fallback for this specific environment, try a relative path (not ideal for robust tests)
+    import sys
+    sys.path.append(os.path.join(os.path.dirname(__file__), 'pelican/plugins'))
+    from humans.humans import generate_humans_txt, register
+
+
+class TestHumansPlugin(unittest.TestCase):
+
+    def setUp(self):
+        self.temp_output_dir = tempfile.mkdtemp()
+        self.settings = DEFAULT_CONFIG.copy()
+        self.settings['OUTPUT_PATH'] = self.temp_output_dir
+        self.settings['PATH'] = 'content' # Dummy content path
+        self.settings['SITEURL'] = 'http://localhost'
+        # Ensure plugin is registered for testing its signal connection if needed,
+        # but here we'll call generate_humans_txt directly for simplicity.
+        # register() # This would normally be called by Pelican
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_output_dir)
+
+    def _get_pelican_object(self, override_settings=None):
+        settings = self.settings.copy()
+        if override_settings:
+            settings.update(override_settings)
+        return Pelican(settings)
+
+    def test_default_humans_txt_generation(self):
+        pelican_obj = self._get_pelican_object()
+        generate_humans_txt(pelican_obj)
+
+        humans_file_path = os.path.join(self.temp_output_dir, "humans.txt")
+        self.assertTrue(os.path.exists(humans_file_path))
+
+        with open(humans_file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        self.assertIn("/* TEAM */", content)
+        self.assertIn("/* THANKS */", content)
+        self.assertIn("/* SITE */", content)
+        self.assertIn(f"Last update: {datetime.now().strftime('%Y/%m/%d')}", content)
+        self.assertIn("Standards: HTML5, CSS3", content)
+        self.assertIn("Components: Pelican", content)
+        self.assertIn("Software: Python", content)
+
+    def test_custom_team_list_generation(self):
+        custom_settings = {
+            'HUMANS_TEAM': [
+                'Lead Developer: Jules Verne',
+                'Support: Phileas Fogg'
+            ]
+        }
+        pelican_obj = self._get_pelican_object(custom_settings)
+        generate_humans_txt(pelican_obj)
+
+        humans_file_path = os.path.join(self.temp_output_dir, "humans.txt")
+        with open(humans_file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        self.assertIn("/* TEAM */", content)
+        self.assertIn("Lead Developer: Jules Verne", content)
+        self.assertIn("Support: Phileas Fogg", content)
+        self.assertNotIn("Default Team Member", content) # Assuming default might have this
+
+    def test_custom_team_dict_generation(self):
+        custom_settings = {
+            'HUMANS_TEAM': {
+                'Project Lead': 'Captain Nemo',
+                'Mascot': 'Nautilus'
+            }
+        }
+        pelican_obj = self._get_pelican_object(custom_settings)
+        generate_humans_txt(pelican_obj)
+
+        humans_file_path = os.path.join(self.temp_output_dir, "humans.txt")
+        with open(humans_file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        self.assertIn("/* TEAM */", content)
+        self.assertIn("Project Lead: Captain Nemo", content)
+        self.assertIn("Mascot: Nautilus", content)
+
+    def test_custom_thanks_list_generation(self):
+        custom_settings = {
+            'HUMANS_THANKS': [
+                'BigFramework Team - For their awesome framework',
+                'CoffeeShop - For the endless supply of caffeine'
+            ]
+        }
+        pelican_obj = self._get_pelican_object(custom_settings)
+        generate_humans_txt(pelican_obj)
+
+        humans_file_path = os.path.join(self.temp_output_dir, "humans.txt")
+        with open(humans_file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        self.assertIn("/* THANKS */", content)
+        self.assertIn("BigFramework Team - For their awesome framework", content)
+        self.assertIn("CoffeeShop - For the endless supply of caffeine", content)
+
+    def test_custom_site_dict_generation(self):
+        custom_settings = {
+            'HUMANS_SITE': {
+                'Language': 'en-US',
+                'Doctype': 'HTML5',
+                'IDE': 'VS Code'
+            }
+        }
+        pelican_obj = self._get_pelican_object(custom_settings)
+        generate_humans_txt(pelican_obj)
+
+        humans_file_path = os.path.join(self.temp_output_dir, "humans.txt")
+        with open(humans_file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        self.assertIn("/* SITE */", content)
+        self.assertIn("Language: en-US", content)
+        self.assertIn("Doctype: HTML5", content)
+        self.assertIn("IDE: VS Code", content)
+        self.assertIn(f"Last update: {datetime.now().strftime('%Y/%m/%d')}", content) # Should still be there
+
+    def test_mixed_custom_and_default_generation(self):
+        custom_settings = {
+            'HUMANS_TEAM': [
+                'The One And Only: Me'
+            ]
+            # HUMANS_THANKS and HUMANS_SITE will use defaults
+        }
+        pelican_obj = self._get_pelican_object(custom_settings)
+        generate_humans_txt(pelican_obj)
+
+        humans_file_path = os.path.join(self.temp_output_dir, "humans.txt")
+        with open(humans_file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        self.assertIn("/* TEAM */", content)
+        self.assertIn("The One And Only: Me", content)
+
+        self.assertIn("/* THANKS */", content) # Default thanks section header
+
+        self.assertIn("/* SITE */", content) # Default site section header
+        self.assertIn("Standards: HTML5, CSS3", content) # Default site content
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces a new Pelican plugin that dynamically generates a `humans.txt` file for the site.

Features:
- Creates `pelican/plugins/humans` with plugin logic.
- Allows customization of TEAM, THANKS, and SITE sections via `pelicanconf.py` settings (`HUMANS_TEAM`, `HUMANS_THANKS`, `HUMANS_SITE`).
- Provides default content if settings are not specified.
- Includes unit tests for the plugin functionality.
- Adds a README for plugin usage and configuration.