### PR TITLE
feat: Add static pages and configure humans.txt

### DIFF
--- a/content/pages/about.rst
+++ b/content/pages/about.rst
@@ -1,0 +1,13 @@
+About Me
+########
+
+:Title: About Me
+:Slug: about
+:Authors: Jeremy Rist
+:Date: 2024-03-10
+
+Hello! My name is Jeremy Rist.
+
+I am a passionate software engineer with a keen interest in web development, open source, and building useful tools. This website serves as a place to share my thoughts, projects, and journey in the tech world.
+
+Feel free to explore my blog posts and project portfolio.

--- a/content/pages/portfolio.rst
+++ b/content/pages/portfolio.rst
@@ -1,0 +1,17 @@
+My Portfolio
+############
+
+:Title: Portfolio
+:Slug: portfolio
+:Authors: Jeremy Rist
+:Date: 2024-03-10
+
+Welcome to my portfolio. Here you'll find a selection of projects I've worked on, showcasing my skills and interests.
+
+Each project has its own page with more details.
+
+Current Projects
+================
+
+*   [Project 1 Title](./project-1.html) - A brief description of Project 1.
+*   *(More projects will be listed here as they are added)*

--- a/content/pages/project-1.rst
+++ b/content/pages/project-1.rst
@@ -1,0 +1,40 @@
+Project 1: Awesome Tool
+#########################
+
+:Title: Project 1: Awesome Tool
+:Slug: project-1
+:Authors: Jeremy Rist
+:Date: 2024-03-10
+:Summary: A detailed look at Awesome Tool, a project that solves an interesting problem.
+
+This page describes Project 1, "Awesome Tool".
+
+Overview
+========
+
+A brief introduction to what Awesome Tool is and what it does.
+
+Technologies Used
+=================
+
+*   Python
+*   Flask
+*   JavaScript
+
+Features
+========
+
+*   Feature A
+*   Feature B
+*   Feature C
+
+Challenges and Learning
+=======================
+
+A discussion of any interesting challenges faced during development and what was learned.
+
+Links
+=====
+
+*   `Live Demo (if applicable) <#>`_
+*   `Source Code on GitHub <#>`_

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -74,7 +74,7 @@ PAGINATED_TEMPLATES = {'index': None} # Updated to dict format; None uses DEFAUL
 # By default, if these are not set, the plugin will use generic information.
 # You can override specific sections or leave them for defaults.
 # For example, to only specify the team:
-# HUMANS_TEAM = [
-#     {'Author': 'Jeremy Rist', 'Role': 'Owner', 'Contact': 'jeremy@rist.dev', 'Mastodon': '@jrist@awscommunity.social'}
-# ]
+HUMANS_TEAM = [
+    {'Author': 'Jeremy Rist', 'Role': 'Owner/Developer', 'Contact': 'jeremy@rist.dev'}
+]
 # The /* SITE */ section will always include "Last update".


### PR DESCRIPTION
Adds the following static pages:
- About page (/about.html)
- Portfolio landing page (/portfolio.html)
- Placeholder for Project 1 page (/project-1.html)

Updates pelicanconf.py:
- Ensures DISPLAY_PAGES_ON_MENU is True for automatic menu generation.
- Configures HUMANS_TEAM for the humans.txt plugin.