### PR TITLE
Style: Adjust header padding and metadata layout

### DIFF
--- a/themes/risterio-simple/static/css/style.css
+++ b/themes/risterio-simple/static/css/style.css
@@ -93,6 +93,11 @@ article h2 a:hover {
     padding-left: 10px;
 }
 
+/* Ensure metadata under article titles has some space */
+article header div small {
+    display: inline-block; /* To allow margin-top */
+    margin-top: 0.5em;
+}
 
 aside {
     flex: 1; /* Takes 1 part of the space */
@@ -136,7 +141,7 @@ aside ul li a:hover {
 header {
     background-color: var(--header-bg-color);
     color: var(--header-text-color);
-    padding: 2em 1.5em; /* Generous padding */
+    padding: 1em 1.5em; /* Reduced top/bottom padding */
     display: flex;
     align-items: center;
     flex-wrap: wrap;

--- a/themes/risterio-simple/templates/article.html
+++ b/themes/risterio-simple/templates/article.html
@@ -6,7 +6,7 @@
 <article class="single-article">
     <header>
         <h2>{{ article.title }}</h2>
-        <p><small>
+        <div><small>
             Published: {{ article.locale_date }}
             {% if article.category %}
             | Category: <a href="{{ SITEURL }}/{{ article.category.url }}">{{ article.category }}</a>
@@ -17,7 +17,7 @@
             <a href="{{ SITEURL }}/{{ tag.url }}">{{ tag }}</a>{% if not loop.last %}, {% endif %}
             {% endfor %}
             {% endif %}
-        </small></p>
+        </small></div>
     </header>
     <section class="article-content">
         {{ article.content }}

--- a/themes/risterio-simple/templates/index.html
+++ b/themes/risterio-simple/templates/index.html
@@ -13,12 +13,12 @@
         <article>
             <header>
                 <h3><a href="{{ SITEURL }}/{{ article.url }}" rel="bookmark" title="Permalink to {{ article.title|striptags }}">{{ article.title }}</a></h3>
-                <p><small>
+                <div><small>
                     Published: {{ article.locale_date }}
                     {% if article.category %}
                     | Category: <a href="{{ SITEURL }}/{{ article.category.url }}">{{ article.category }}</a>
                     {% endif %}
-                </small></p>
+                </small></div>
             </header>
             <section>
                 {{ article.summary }}


### PR DESCRIPTION
- Reduced top and bottom padding for the main site header.
- Changed metadata container from <p> to <div> in article and index templates to ensure it appears on a new line.
- Added a small top margin to the metadata for better spacing.