### PR TITLE
docs: Clarify licensing for code and content with NoDerivatives

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,6 @@
 Copyright (c) 2025 Jeremy Rist
 
-All Rights Reserved.
+Code sections are licensed under the MIT License.
+
+Site content is licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License.
+To view a copy of this license, visit http://creativecommons.org/licenses/by-nc-nd/4.0/ or send a letter to Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.


### PR DESCRIPTION
Updated the LICENSE file to specify that code sections are licensed under MIT, and site content is licensed under Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International.