### PR TITLE
Fix: Add specific templates for archives, categories, and authors

### DIFF
--- a/themes/ClutteredDesk/templates/archives.html
+++ b/themes/ClutteredDesk/templates/archives.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{% block title %}Archives - {{ SITENAME }}{% endblock %}
+
+{% block content %}
+<article class="hentry">
+    <header>
+        <h1 class="entry-title">Archives</h1>
+    </header>
+    <div class="entry-content">
+        <dl>
+            {% for article in dates %}
+            <dt>{{ article.locale_date }}</dt>
+            <dd><a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}</a></dd>
+            {% endfor %}
+        </dl>
+    </div>
+</article>
+{% endblock content %}

--- a/themes/ClutteredDesk/templates/authors.html
+++ b/themes/ClutteredDesk/templates/authors.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block title %}Authors - {{ SITENAME }}{% endblock %}
+
+{% block content %}
+<article class="hentry">
+    <header>
+        <h1 class="entry-title">Authors</h1>
+    </header>
+    <div class="entry-content">
+        <ul>
+            {% for author, articles in authors %}
+            <li><a href="{{ SITEURL }}/{{ author.url }}">{{ author }}</a> ({{ articles|count }})</li>
+            {% endfor %}
+        </ul>
+    </div>
+</article>
+{% endblock content %}

--- a/themes/ClutteredDesk/templates/categories.html
+++ b/themes/ClutteredDesk/templates/categories.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block title %}Categories - {{ SITENAME }}{% endblock %}
+
+{% block content %}
+<article class="hentry">
+    <header>
+        <h1 class="entry-title">Categories</h1>
+    </header>
+    <div class="entry-content">
+        <ul>
+            {% for cat, articles in categories %}
+            <li><a href="{{ SITEURL }}/{{ cat.url }}">{{ cat }}</a> ({{ articles|count }})</li>
+            {% endfor %}
+        </ul>
+    </div>
+</article>
+{% endblock content %}


### PR DESCRIPTION
Directly generated pages like archives, categories, and authors were missing the themed article background because they lacked specific templates in the theme and Pelican's default rendering for them did not include an <article> tag.

This change adds `archives.html`, `categories.html`, and `authors.html` to the `themes/ClutteredDesk/templates/` directory. These templates extend `base.html` and wrap their respective content within an `<article class="hentry">` tag, ensuring they receive the correct background styling consistent with other content pages.